### PR TITLE
Version 0.4.23

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ requirements:
     - jaxlib >=0.4.19
     - importlib_metadata >=4.6  # [py<310]
     - ml_dtypes >=0.2.0
+  run_constrained:
+    - protobuf >=3.13,<4
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,12 @@ requirements:
     - setuptools
   run:
     - python
-    - numpy >=1.22
+    - numpy >=1.22    # [py<311]
+    - numpy >-1.23.2 # [py==311]
+    - numpy >-1.26.0 # [py>=312]
     - opt_einsum
-    - scipy >=1.9
+    - scipy >=1.9  # [py<312]
+    - scipy >=1.11.1  # [py>=312]
     # Not declared in the metadata but essential to this package.
     # Update minimum from https://github.com/google/jax/blob/jaxlib-v0.3.25/jax/version.py
     - jaxlib >=0.4.19

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,8 @@ requirements:
   run:
     - python
     - numpy >=1.22    # [py<311]
-    - numpy >-1.23.2 # [py==311]
-    - numpy >-1.26.0 # [py>=312]
+    - numpy >=1.23.2  # [py==311]
+    - numpy >=1.26.0  # [py>=312]
     - opt_einsum
     - scipy >=1.9  # [py<312]
     - scipy >=1.11.1  # [py>=312]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jax" %}
-{% set version = "0.4.16" %}
+{% set version = "0.4.23" %}
 
 package:
   name: {{name}}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/{{name}}/{{name}}-{{ version }}.tar.gz
-  sha256: e2ca82c9bf973c2c1c01f5340a583692b31f277aa3abd0544229c1fe5fa44b02
+  sha256: 2a229a5a758d1b803891b2eaed329723f6b15b4258b14dc0ccb1498c84963685
 
 build:
   number: 0
   # Matches jaxlib-feedstock's compatibility
-  skip: true  # [ppc64le or s390x or win or py<39]
+  skip: true  # [s390x or win or py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -25,10 +25,10 @@ requirements:
     - python
     - numpy >=1.22
     - opt_einsum
-    - scipy >=1.7
+    - scipy >=1.9
     # Not declared in the metadata but essential to this package.
     # Update minimum from https://github.com/google/jax/blob/jaxlib-v0.3.25/jax/version.py
-    - jaxlib >=0.4.14
+    - jaxlib >=0.4.19
     - importlib_metadata >=4.6  # [py<310]
     - ml_dtypes >=0.2.0
 


### PR DESCRIPTION
jax 0.4.23

**Destination channel:** defaults

### Links

- [PKG-3794](https://anaconda.atlassian.net/browse/PKG-3794)
- [Upstream repository](https://github.com/google/jax/tree/main)
- [Upstream changelog/diff](https://github.com/google/jax/blob/main/CHANGELOG.md)

### Explanation of changes:

- Update to `0.4.23`
- Remove `ppc64le`
- Update dependencies

[PKG-3794]: https://anaconda.atlassian.net/browse/PKG-3794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ