### PR TITLE
V0.4.23 win support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-aggregate_branch: 3.12
-
-# Temporary, to be removed before merging. 
-channels:
-  - https://staging.continuum.io/prefect/fs/jaxlib-feedstock/pr8/a1916ca

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,5 @@
 aggregate_branch: 3.12
+
+# Temporary, to be removed before merging. 
+channels:
+  - https://staging.continuum.io/prefect/fs/jaxlib-feedstock/pr8/a1916ca

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 2a229a5a758d1b803891b2eaed329723f6b15b4258b14dc0ccb1498c84963685
 
 build:
-  number: 0
+  number: 1
   # Matches jaxlib-feedstock's compatibility
-  skip: true  # [s390x or win or py<39]
+  skip: true  # [s390x or py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
jax v0.4.23 rebuild

- Adds windows support

**Destination channel:** defaults

### Links

- [/PKG-3383](https://anaconda.atlassian.net/browse/PKG-3383) 
- [Upstream repository](https://github.com/jax-ml/jax/tree/jax-v0.4.23)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/jaxlib-feedstock/pull/8
  - https://github.com/AnacondaRecipes/jax-feedstock/pull/3

### Explanation of changes:

- Bump build number
- Don't skip Windows
- Adjust numpy pinning for py3.13
