### PR TITLE
v0.4.35

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/jaxlib-feedstock/pr9/396705a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/jaxlib-feedstock/pr9/396705a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jax" %}
-{% set version = "0.4.23" %}
+{% set version = "0.4.35" %}
 
 package:
   name: {{name}}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/{{name}}/{{name}}-{{ version }}.tar.gz
-  sha256: 2a229a5a758d1b803891b2eaed329723f6b15b4258b14dc0ccb1498c84963685
+  sha256: c0c986993026b10bf6f607fecb7417377460254640766ce40f1fef3fd139c12e
 
 build:
   number: 1
@@ -23,17 +23,15 @@ requirements:
     - setuptools
   run:
     - python
-    - numpy >=1.22    # [py<311]
-    - numpy >=1.23.2  # [py==311]
+    - numpy >=1.24    # [py<312]
     - numpy >=1.26.0  # [py>=312]
     - opt_einsum
-    - scipy >=1.9  # [py<312]
+    - scipy >=1.10  # [py<312]
     - scipy >=1.11.1  # [py>=312]
+    - jaxlib {{version}}
     # Not declared in the metadata but essential to this package.
-    # Update minimum from https://github.com/google/jax/blob/jaxlib-v0.3.25/jax/version.py
-    - jaxlib >=0.4.19
     - importlib_metadata >=4.6  # [py<310]
-    - ml_dtypes >=0.2.0
+    - ml_dtypes >=0.4.0
   run_constrained:
     - protobuf >=3.13,<4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 1
   # Matches jaxlib-feedstock's compatibility
-  skip: true  # [s390x or py<39]
+  skip: true  # [s390x or py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c0c986993026b10bf6f607fecb7417377460254640766ce40f1fef3fd139c12e
 
 build:
-  number: 1
+  number: 0
   # Matches jaxlib-feedstock's compatibility
   skip: true  # [s390x or py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,6 @@ requirements:
     # Not declared in the metadata but essential to this package.
     - importlib_metadata >=4.6  # [py<310]
     - ml_dtypes >=0.4.0
-  run_constrained:
-    - protobuf >=3.13,<4
 
 test:
   imports:


### PR DESCRIPTION
jax v0.4.35 
**Destination channel:** defaults

### Links

- [PKG-5910](https://anaconda.atlassian.net/browse/PKG-5910) 
- [Upstream repository](https://github.com/jax-ml/jax/tree/jax-v0.4.35)
- [Upstream changelog/diff](https://github.com/jax-ml/jax/releases/tag/jax-v0.4.35)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/jaxlib-feedstock/pull/9
- Links
  - [setup.py](https://github.com/jax-ml/jax/blob/jax-v0.4.35/setup.py#L57-L64)
  - [jaxlib version](https://github.com/jax-ml/jax/blob/jax-v0.4.35/jax/version.py#L136)

### Explanation of changes:

- Bump version and SHA
- Adjust python compatibility to match jaxlib
- Update dependencies according to setup.py
- Add a temporary staging channel to be removed before merging 


[PKG-5910]: https://anaconda.atlassian.net/browse/PKG-5910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ