### PR TITLE
build jax 0.4.25

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a8ee189c782de2b7b2ffb64a8916da380b882a617e2769aa429b71d79747b982
 
 build:
-  number: 1
+  number: 0
   # Matches jaxlib-feedstock's compatibility
   skip: true  # [s390x or py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
jaxlib 0.4.25 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6694] 
- [Upstream repository]()
- [Upstream changelog/diff]()

### Explanation of changes:

- build `0.4.25` so we can satisfy `numpyro` for `py39`,`py310`


[PKG-6144]: https://anaconda.atlassian.net/browse/PKG-6144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-6694]: https://anaconda.atlassian.net/browse/PKG-6694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ