### PR TITLE
jax 0.9.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jax" %}
-{% set version = "0.7.2" %}
+{% set version = "0.9.2" %}
 
 package:
   name: {{name}}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/j/jax/jax-{{ version }}.tar.gz
-  sha256: 71a42b964bc6d52e819311429e6c0f5742e2a4650226dab1a1dd26fd986ca70d
+  sha256: 42b28017b3e6b57a44b0274cc15f5153239c4873959030399ac1afc009c22365
 
 build:
   number: 0
@@ -25,7 +25,6 @@ requirements:
     - numpy >=2.0
     - opt_einsum
     - scipy >=1.13
-    - importlib_metadata >=4.6
     - ml_dtypes >=0.5.0
     - jaxlib {{ version }}
   run_constrained:


### PR DESCRIPTION
## jax 0.9.2

**Destination channel:** defaults

### Links
- [PKG-10581](https://anaconda.atlassian.net/browse/PKG-10581) (parent epic [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074) - 2026Q2 AI & Growth Packages)
- Upstream: https://github.com/jax-ml/jax/releases/tag/jax-v0.9.2
- Conda-forge reference: https://github.com/conda-forge/jax-feedstock
- jaxlib 0.9.2 dependency: [AnacondaRecipes/jaxlib-feedstock#27](https://github.com/AnacondaRecipes/jaxlib-feedstock/pull/27) (merged, released to pkgs/main)

### Explanation of changes

- Bumped `jax` from 0.7.2 to 0.9.2; reset build number to 0
- Updated source SHA256 to match the new `jax-0.9.2.tar.gz` from PyPI
- Removed obsolete `anaconda.yaml` (recipe-bumper config no longer in use)
- Dropped `importlib_metadata >=4.6` from `run` deps. Upstream [jax v0.9.2 setup.py install_requires](https://github.com/jax-ml/jax/blob/jax-v0.9.2/setup.py#L88-L94) lists only `jaxlib`, `ml_dtypes>=0.5.0`, `numpy>=2.0`, `opt_einsum`, `scipy>=1.13`. The recipe already skips `py<311`, so the stdlib `importlib.metadata` covers what the third-party backport used to provide.

### Run deps vs upstream

| dep | upstream `install_requires` | recipe |
|---|---|---|
| `jaxlib` | `>=0.9.2, <=0.9.2` | `jaxlib {{ version }}` ✓ |
| `ml_dtypes` | `>=0.5.0` | `>=0.5.0` ✓ |
| `numpy` | `>=2.0` | `>=2.0` ✓ |
| `opt_einsum` | (no version) | (no version) ✓ |
| `scipy` | `>=1.13` | `>=1.13` ✓ |

`run_constrained` keeps `cudnn >=9.8,<10.0` from the prior recipe (matches upstream `jax_plugins/cuda/plugin_setup.py`).

CUDA / TPU plugins (`jax-cuda12-plugin`, `jax-cuda13-plugin`, `libtpu`, `xprof`) are upstream optional extras and are NOT added to `run_constrained` because none of those packages exist on pkgs/main yet.

### Notes for reviewers

- Pure-Python noarch-style package; depends on the just-released jaxlib 0.9.2 (CPU + CUDA 12.9 + CUDA 13.0 variants on linux-64 / linux-aarch64; CPU on osx-arm64 / win-64)
- No source patches needed

[PKG-10581]: https://anaconda.atlassian.net/browse/PKG-10581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ